### PR TITLE
Update pref_cmd.py

### DIFF
--- a/onedrive_d/pref_cmd.py
+++ b/onedrive_d/pref_cmd.py
@@ -122,4 +122,8 @@ class OneDrive_PreferenceDialog:
 		self.show_log_path_dialog()
 		self.show_ignore_list_dialog()
 		config.save_config()
+		
+		#Add this line somewhere your project to create a command to the user
+		subprocess.call(["ln","-s",os.getcwd()+"/main.py","/bin/onedrive-d"])
+		
 		print('\nAll steps have been gone through.')


### PR DESCRIPTION
Adding a command to the user path, at /bin/, to execute the main.py program as a command line, in this case onedrive-d. At least, in Fedora 20 it's working fine.
